### PR TITLE
Fix namespace, refactor

### DIFF
--- a/ParserCombinator.sln
+++ b/ParserCombinator.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParserCombinator", "ParserCombinator\ParserCombinator.csproj", "{B6EEB739-E7FA-41AB-B09F-F24519108C8E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VArnas.ParserCombinator", "VArnas.ParserCombinator\VArnas.ParserCombinator.csproj", "{B6EEB739-E7FA-41AB-B09F-F24519108C8E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{977C7806-8602-45B2-AFFF-BC444155B6AB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VArnas.UnitTests", "VArnas.UnitTests\VArnas.UnitTests.csproj", "{977C7806-8602-45B2-AFFF-BC444155B6AB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vowelParser
     .Map(Console.Write);
 
 ```
-
+aa
 ## More complicated example
 
 This is an example of a parser that parses number palindromes of length 5 (12321, 98789, etc...) and converts the result to a number.

--- a/VArnas.ParserCombinator/CharacterParsers.cs
+++ b/VArnas.ParserCombinator/CharacterParsers.cs
@@ -1,6 +1,7 @@
-using static ParserCombinator.Core.CommonParsers;
+using System.Linq;
+using static VArnas.ParserCombinator.CommonParsers;
 
-namespace ParserCombinator.Core;
+namespace VArnas.ParserCombinator;
 
 public static class CharacterParsers
 {

--- a/VArnas.ParserCombinator/Either.cs
+++ b/VArnas.ParserCombinator/Either.cs
@@ -1,7 +1,8 @@
-﻿using System.Diagnostics;
-using static ParserCombinator.Core.Either;
+﻿using System;
+using System.Diagnostics;
+using static VArnas.ParserCombinator.Either;
 
-namespace ParserCombinator.Core;
+namespace VArnas.ParserCombinator;
 
 /// <summary>
 /// Represents a calculation that can fail.

--- a/VArnas.ParserCombinator/ParseResult.cs
+++ b/VArnas.ParserCombinator/ParseResult.cs
@@ -1,10 +1,12 @@
-namespace ParserCombinator.Core;
+using System;
+
+namespace VArnas.ParserCombinator;
 
 public class ParseResult<TSymbol, TResult>(TResult result, ParserInput<TSymbol> remaining)
 {
     public TResult Result { get; } = result;
 
-    public ParserInput<TSymbol> Remaining { get; set; } = remaining;
+    public ParserInput<TSymbol> Remaining { get; } = remaining;
 
     public ParseResult<TSymbol, TOther> Map<TOther>(Func<TResult, TOther> func) => 
         new(func(Result), Remaining);

--- a/VArnas.ParserCombinator/ParserExtensions.cs
+++ b/VArnas.ParserCombinator/ParserExtensions.cs
@@ -1,10 +1,13 @@
-using static ParserCombinator.Core.CommonParsers;
+using System.Linq;
+using static VArnas.ParserCombinator.CommonParsers;
 
-namespace ParserCombinator.Core;
+namespace VArnas.ParserCombinator;
 
 public static class ParserExtensions
 {
     public static Either<string, ParseResult<char, TResult>> 
         ParseFromString<TResult>(this Parser<char, TResult> parser, string input) =>
             parser.Parse(new(input.ToArray(), 0));
+    
+    
 }

--- a/VArnas.ParserCombinator/ParserInput.cs
+++ b/VArnas.ParserCombinator/ParserInput.cs
@@ -1,4 +1,6 @@
-namespace ParserCombinator.Core;
+using System.Collections.Generic;
+
+namespace VArnas.ParserCombinator;
 
 /// <summary>
 /// Parser input reads from an immutable source of symbols and tracks the reading position.
@@ -6,4 +8,8 @@ namespace ParserCombinator.Core;
 /// <param name="data">Source of symbols to read from</param>
 /// <param name="offset">Index of a symbol where the parser will begin reading</param>
 /// <typeparam name="TSymbol">Type of symbol</typeparam>
-public record ParserInput<TSymbol>(IReadOnlyCollection<TSymbol> Data, int Offset);
+public class ParserInput<TSymbol>(IReadOnlyCollection<TSymbol> data, int offset)
+{
+    public IReadOnlyCollection<TSymbol> Data { get; } = data;
+    public int Offset { get; set; } = offset;
+}

--- a/VArnas.ParserCombinator/VArnas.ParserCombinator.csproj
+++ b/VArnas.ParserCombinator/VArnas.ParserCombinator.csproj
@@ -11,6 +11,8 @@
         <Version>1.0.0</Version>
         <Authors>Arnas Vaicekauskas</Authors>
         <Description>Functional parser cominators in .NET</Description>
+        <AssemblyName>VArnas.ParserCombinator</AssemblyName>
+        <RootNamespace>VArnas.ParserCombinator</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/VArnas.UnitTests/CharacterParsers/AnyTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/AnyTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class AnyTests
 {

--- a/VArnas.UnitTests/CharacterParsers/ManyTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/ManyTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class ManyTests
 {

--- a/VArnas.UnitTests/CharacterParsers/OneOfTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/OneOfTests.cs
@@ -1,11 +1,9 @@
-using ParserCombinator.Core;
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static ParserCombinator.Core.Parser;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class OneOfTests
 {

--- a/VArnas.UnitTests/CharacterParsers/OrTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/OrTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static ParserCombinator.Core.Parser;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.ParserCombinator.Parser;
+using static VArnas.UnitTests.TestHelpers;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class OrTests
 {

--- a/VArnas.UnitTests/CharacterParsers/RepeatTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/RepeatTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class RepeatTests
 {

--- a/VArnas.UnitTests/CharacterParsers/SatisfyTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/SatisfyTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class SatisfyTests
 {

--- a/VArnas.UnitTests/CharacterParsers/SeqTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/SeqTests.cs
@@ -1,9 +1,9 @@
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class SeqTests
 {

--- a/VArnas.UnitTests/CharacterParsers/SomeTests.cs
+++ b/VArnas.UnitTests/CharacterParsers/SomeTests.cs
@@ -1,10 +1,9 @@
-using System.Runtime.InteropServices;
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.CharacterParsers;
+namespace VArnas.UnitTests.CharacterParsers;
 
 public class SomeTests
 {
@@ -14,7 +13,7 @@ public class SomeTests
         "some lexer has to always succeed and the result will be an empty array".ToArray(),
         Empty<char>(),
         0);
-    
+
     [Theory]
     [InlineData("")]
     [InlineData("a?")]

--- a/VArnas.UnitTests/Complex/BoundedIntegerTests.cs
+++ b/VArnas.UnitTests/Complex/BoundedIntegerTests.cs
@@ -1,11 +1,11 @@
-using ParserCombinator.Core;
+using VArnas.ParserCombinator;
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static ParserCombinator.Core.Parser;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.ParserCombinator.Parser;
+using static VArnas.UnitTests.TestHelpers;
 using static System.Array;
 
-namespace UnitTests.Complex;
+namespace VArnas.UnitTests.Complex;
 
 public class BoundedIntegerTests
 {

--- a/VArnas.UnitTests/Complex/NumberPalindromeTests.cs
+++ b/VArnas.UnitTests/Complex/NumberPalindromeTests.cs
@@ -1,10 +1,10 @@
-using ParserCombinator.Core;
+using VArnas.ParserCombinator;
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static ParserCombinator.Core.Parser;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.ParserCombinator.Parser;
+using static VArnas.UnitTests.TestHelpers;
 
-namespace UnitTests.Complex;
+namespace VArnas.UnitTests.Complex;
 
 public class NumberPalindromeTests
 {

--- a/VArnas.UnitTests/Complex/VowelTests.cs
+++ b/VArnas.UnitTests/Complex/VowelTests.cs
@@ -1,9 +1,9 @@
-using ParserCombinator.Core;
+using VArnas.ParserCombinator;
 using Xunit;
-using static ParserCombinator.Core.CommonParsers;
-using static UnitTests.TestHelpers;
+using static VArnas.ParserCombinator.CommonParsers;
+using static VArnas.UnitTests.TestHelpers;
 
-namespace UnitTests.Complex;
+namespace VArnas.UnitTests.Complex;
 
 public class VowelTests
 {

--- a/VArnas.UnitTests/TestHelpers.cs
+++ b/VArnas.UnitTests/TestHelpers.cs
@@ -1,7 +1,7 @@
-using ParserCombinator.Core;
+using VArnas.ParserCombinator;
 using Xunit;
 
-namespace UnitTests;
+namespace VArnas.UnitTests;
 
 public static class TestHelpers
 {

--- a/VArnas.UnitTests/VArnas.UnitTests.csproj
+++ b/VArnas.UnitTests/VArnas.UnitTests.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\ParserCombinator\ParserCombinator.csproj" />
+      <ProjectReference Include="..\VArnas.ParserCombinator\VArnas.ParserCombinator.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changes:
- Change root namespace to `VArnas.X`
- Rewrite some parsers without using expensive functions.